### PR TITLE
[feat] 맥도날드 버튼 컴포넌트 구현

### DIFF
--- a/MCDONALDS_iOS/MCDONALDS_iOS.xcodeproj/project.pbxproj
+++ b/MCDONALDS_iOS/MCDONALDS_iOS.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		E3D763392DCDD79C00851149 /* Exceptions for "MCDONALDS_iOS" folder in "MCDONALDS_iOS" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				Global/Components/.gitkeep,
 				Global/Enums/.gitkeep,
 				Info.plist,
 				Network/.gitkeep,

--- a/MCDONALDS_iOS/MCDONALDS_iOS/Global/Components/McdonaldsButton.swift
+++ b/MCDONALDS_iOS/MCDONALDS_iOS/Global/Components/McdonaldsButton.swift
@@ -1,0 +1,111 @@
+//
+//  McdonaldsButton.swift
+//  MCDONALDS_iOS
+//
+//  Created by 김승원 on 5/13/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+/// 맥도날드 버튼 컴포넌트입니다.
+final class McdonaldsButton: UIButton {
+    
+    // MARK: - Properties
+
+    private let cornerRadius: CGFloat = 4
+    private let borderColor: UIColor = .grayScale200
+    
+    // MARK: - Initializer
+    
+    init(_ title: String, type: McdonalsButtonType) {
+        super.init(frame: .zero)
+        
+        setButton(title, type: type)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Functions
+
+extension McdonaldsButton {
+    private func setButton(_ title: String, type: McdonalsButtonType) {
+        setTitle(title, for: .normal)
+        setTitleColor(.grayScale800, for: .normal)
+        titleLabel?.font = .pretendard(.bodyReg13)
+        backgroundColor = type.backgroundColor
+        clipsToBounds = true
+        
+        if type.hasRoundedCorners {
+            setCornerRadius(cornerRadius)
+        }
+        
+        if type.hasBorder {
+            setButtonBorder()
+        }
+    }
+    
+    private func setButtonBorder() {
+        let borderView = UIView()
+        
+        borderView.do {
+            $0.backgroundColor = .clear
+            $0.isUserInteractionEnabled = false
+            $0.setBorder(borderColor: borderColor)
+        }
+        
+        addSubview(borderView)
+        
+        borderView.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(-1)
+        }
+    }
+}
+
+extension McdonaldsButton {
+    
+    /// 맥도날드 버튼 컴포넌트에 사용되는 enum입니다
+    /// 1. plainYellow - 기본 노란 버튼
+    /// 2. roundedYellow - 둥근 노란 버튼
+    /// 3. outlinedYellow - 외각선 노란 버튼
+    /// 4. outlinedWhite - 외각선 흰 버튼
+    enum McdonalsButtonType {
+        case plainYellow
+        case roundedYellow
+        case outlinedYellow
+        case outlinedWhite
+        
+        var backgroundColor: UIColor {
+            switch self {
+            case .plainYellow, .roundedYellow, .outlinedYellow:
+                return .mainYellow
+            case .outlinedWhite:
+                return .staticWhite
+            }
+        }
+        
+        var hasRoundedCorners: Bool {
+            switch self {
+            case .plainYellow, .outlinedYellow, .outlinedWhite:
+                return false
+            case .roundedYellow:
+                return true
+            }
+        }
+        
+        var hasBorder: Bool {
+            switch self {
+            case .plainYellow, .roundedYellow:
+                return false
+            case .outlinedYellow, .outlinedWhite:
+                return true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🍔 작업 내용
> 작업한 내용을 두괄식으로 작성해주세요
- 공통으로 사용되는 버튼 컴포넌트를 구현했습니다

<img src = "https://github.com/user-attachments/assets/d8d3ec90-c966-45a4-8d93-6cb33e945896" width ="600">
<img src = "https://github.com/user-attachments/assets/966fd2bd-77ba-4b1d-b9b5-2a4a6af0ca90" width ="500">

- 자세히 보니까 버튼 중에 위 아래로 .grayScale200 색상의 외각선이 붙어있는 버튼이 있더라고요
- 그래서 `1. 기본 노란 버튼`, `2. 둥근 노란 버튼`, `3. 외각선 노란 버튼`, `4. 외각선 흰 버튼` 이렇게 4가지 만들었어요



## 🍟 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
> 설명이 필요한 코드 위주로 작성해주세요
### McdonalsButtonType
```Swift
 enum McdonalsButtonType {
     case plainYellow
     case roundedYellow
     case outlinedYellow
     case outlinedWhite

    // ...
```
- 문서화 주석으로 설명을 작성해 놓긴 했습니다
1. plainYellow - 기본 노란 버튼
2. roundedYellow - 둥근 노란 버튼
3. outlinedYellow - 외각선 노란 버튼
4. outlinedWhite - 외각선 흰 버튼
- 각자 필요한 버튼 확인하시고 사용하시면 되겠습니다

### 사용 방법
```Swift
let button1 = McdonaldsButton("기본 노란 버튼", type: .plainYellow)
let button2 = McdonaldsButton("둥근 노란 버튼", type: .roundedYellow)
let button3 = McdonaldsButton("외각선 노란 버튼", type: .outlinedYellow)
let button4 = McdonaldsButton("외각선 흰 버튼", type: .outlinedWhite)
```
- UI 프로퍼티는 이렇게 선언해 주시면 되고
- autolayout은 피그마 보고 알아서 잡아주시면 됩니다!!


## 🍔 구현화면
> 시뮬레이터 사진 또는 gif파일을 첨부해 주세요.

|   버튼 이미지   |
| :----------: |
| <img src = "https://github.com/user-attachments/assets/119c16d7-70d9-479e-8332-ae1459ab5f63" width ="250">



## 🍟 연결된 이슈
> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)
- Connected: #10 


## 🍟 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 공통 컴포넌트에 대한 내용이니 PR 꼼꼼하게 읽어 주시고, 리뷰해 주세요 🍔