### PR TITLE
[Feat/#17] 주문하기 뷰 구현

### DIFF
--- a/MCDONALDS_iOS/MCDONALDS_iOS/Global/Components/AccordionMenu/BeverageMenu/ExpandedIceEAView.swift
+++ b/MCDONALDS_iOS/MCDONALDS_iOS/Global/Components/AccordionMenu/BeverageMenu/ExpandedIceEAView.swift
@@ -63,7 +63,7 @@ final class ExpandedIceEAView: UIView {
         allStackView.do {
             $0.axis = .horizontal
             $0.alignment = .center
-            $0.spacing = 194
+            $0.spacing = 172
             $0.addArrangedSubviews(nameLabel, eaStackView)
         }
     }

--- a/MCDONALDS_iOS/MCDONALDS_iOS/Global/Components/AccordionMenu/SideMenu/ExpandedEAView.swift
+++ b/MCDONALDS_iOS/MCDONALDS_iOS/Global/Components/AccordionMenu/SideMenu/ExpandedEAView.swift
@@ -63,7 +63,7 @@ final class ExpandedEAView: UIView {
         allStackView.do {
             $0.axis = .horizontal
             $0.alignment = .center
-            $0.spacing = 194
+            $0.spacing = 172
             $0.addArrangedSubviews(nameLabel, eaStackView)
         }
     }

--- a/MCDONALDS_iOS/MCDONALDS_iOS/Presentation/Order/OrderView.swift
+++ b/MCDONALDS_iOS/MCDONALDS_iOS/Presentation/Order/OrderView.swift
@@ -1,0 +1,305 @@
+//
+//  OrderView.swift
+//  MCDONALDS_iOS
+//
+//  Created by 이상엽 on 5/18/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class OrderView: BaseView {
+    
+    // MARK: - UI Properties
+    
+    private let scrollView = UIScrollView()
+    
+    private let contentView = UIView()
+    
+    private let burgerNameLabel = UILabel()
+    
+    let burgerCardView = UIView()
+    
+    private let justBurgerImageView = UIImageView()
+    
+    private let justBurgerLabel = UILabel()
+    
+    private let burgerPriceLabel = UILabel()
+    
+    let comboCardView = UIView()
+    
+    private let comboImageView = UIImageView()
+    
+    private let comboLabel = UILabel()
+    
+    private let comboPriceLabel = UILabel()
+    
+    private let sideMenuView = SideMenuView()
+    
+    private let burgerMenuView = BurgerMenuView()
+    
+    private let beverageMenuView = BeverageMenuView()
+    
+    private let quantityChangeView = UIView()
+    
+    let quantityLabel = UILabel()
+    
+    var quantity: Int = 0
+    
+    let plusButton = UIButton()
+    
+    let minusButton = UIButton()
+    
+    private let infoButton = UIButton()
+    
+    private let goInfoButton = UIButton()
+    
+    private let cartButton = McdonaldsButton("장바구니 담기", type: .outlinedYellow)
+    
+    private let orderButton = McdonaldsButton("바로 주문하기", type: .outlinedWhite)
+
+    
+    // MARK: - UI Settings
+    
+    override func setUI() {
+        addSubviews(scrollView,
+                    cartButton,
+                    orderButton)
+        
+        scrollView.addSubviews(contentView)
+        
+        burgerCardView.addSubviews(justBurgerImageView,
+                                   justBurgerLabel,
+                                   burgerPriceLabel)
+        
+        comboCardView.addSubviews(comboImageView,
+                                  comboLabel,
+                                  comboPriceLabel)
+        
+        quantityChangeView.addSubviews(minusButton,
+                                       quantityLabel,
+                                       plusButton)
+        
+        contentView.addSubviews(burgerNameLabel,
+                                burgerCardView,
+                                comboCardView,
+                                burgerMenuView,
+                                sideMenuView,
+                                beverageMenuView,
+                                infoButton,
+                                goInfoButton,
+                                quantityChangeView)
+    }
+    
+    override func setStyle() {
+        burgerNameLabel.do {
+            $0.font = .pretendard(.headBold29)
+            $0.text = "더블 1955® 버거"
+        }
+        
+        burgerCardView.do {
+            $0.backgroundColor = .clear
+            $0.setBorder(1, borderColor: .grayScale200)
+            $0.layer.cornerRadius = 8
+            $0.isUserInteractionEnabled = true
+        }
+        
+        justBurgerImageView.do {
+            $0.image = UIImage(named: "side-french fries")
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        justBurgerLabel.do {
+            $0.text = "단품"
+            $0.font = .pretendard(.headBold16)
+        }
+        
+        burgerPriceLabel.do {
+            $0.text = "₩9,500"
+            $0.font = .pretendard(.bodyReg13)
+        }
+        
+        comboCardView.do {
+            $0.backgroundColor = .clear
+            $0.setBorder(1, borderColor: .grayScale200)
+            $0.layer.cornerRadius = 8
+            $0.isUserInteractionEnabled = true
+        }
+        
+        comboImageView.do {
+            $0.image = UIImage(named: "side-coleslaw")
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        comboLabel.do {
+            $0.text = "세트"
+            $0.font = .pretendard(.headBold16)
+        }
+        
+        comboPriceLabel.do {
+            $0.text = "₩11,500"
+            $0.font = .pretendard(.bodyReg13)
+        }
+        
+        infoButton.do {
+            $0.setTitle("원산지, 영양성분 및 알레르기 정보", for: .normal)
+            $0.setTitleColor(.grayScale500, for: .normal)
+            $0.titleLabel?.font = .pretendard(.bodyReg14)
+        }
+        
+        goInfoButton.do {
+            $0.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+            $0.tintColor = .grayScale500
+        }
+        
+        quantityChangeView.do {
+            $0.backgroundColor = .clear
+            $0.setBorder(1, borderColor: .grayScale200)
+            $0.layer.cornerRadius = 8
+        }
+        
+        minusButton.do {
+            $0.setImage(UIImage(named: "icon-minus"), for: .normal)
+        }
+        
+        quantityLabel.do {
+            $0.text = "\(quantity)"
+            $0.font = .pretendard(.captionMed19)
+        }
+        
+        plusButton.do {
+            $0.setImage(UIImage(named: "icon-plus"), for: .normal)
+        }
+    }
+    
+    override func setLayout() {
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalTo(scrollView.contentLayoutGuide)
+            $0.width.equalTo(scrollView.frameLayoutGuide)
+        }
+        
+        burgerNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(29)
+            $0.leading.equalToSuperview().offset(28)
+        }
+        
+        burgerCardView.snp.makeConstraints{
+            $0.top.equalTo(burgerNameLabel.snp.bottom).offset(20)
+            $0.leading.equalTo(burgerNameLabel.snp.leading)
+            $0.height.equalTo(204)
+            $0.width.equalTo(150)
+        }
+        
+        justBurgerImageView.snp.makeConstraints{
+            $0.top.equalToSuperview().offset(15)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(120)
+            $0.height.equalTo(104)
+        }
+        
+        justBurgerLabel.snp.makeConstraints {
+            $0.top.equalTo(justBurgerImageView.snp.bottom).offset(20)
+            $0.centerX.equalToSuperview()
+        }
+        
+        burgerPriceLabel.snp.makeConstraints{
+            $0.top.equalTo(justBurgerLabel.snp.bottom).offset(9)
+            $0.centerX.equalToSuperview()
+        }
+        
+        comboCardView.snp.makeConstraints{
+            $0.top.equalTo(burgerCardView)
+            $0.trailing.equalToSuperview().offset(-28)
+            $0.height.equalTo(204)
+            $0.width.equalTo(150)
+        }
+        
+        comboImageView.snp.makeConstraints{
+            $0.top.equalToSuperview().offset(15)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(120)
+            $0.height.equalTo(104)
+        }
+        
+        comboLabel.snp.makeConstraints {
+            $0.top.equalTo(comboImageView.snp.bottom).offset(20)
+            $0.centerX.equalToSuperview()
+        }
+        
+        comboPriceLabel.snp.makeConstraints{
+            $0.top.equalTo(comboLabel.snp.bottom).offset(9)
+            $0.centerX.equalToSuperview()
+        }
+        
+        burgerMenuView.snp.makeConstraints{
+            $0.top.equalTo(burgerCardView.snp.bottom).offset(10)
+            $0.horizontalEdges.equalToSuperview().inset(28)
+        }
+        
+        sideMenuView.snp.makeConstraints {
+            $0.top.equalTo(burgerMenuView.snp.bottom).offset(10)
+            $0.horizontalEdges.equalToSuperview().inset(28)
+        }
+        
+        beverageMenuView.snp.makeConstraints {
+            $0.top.equalTo(sideMenuView.snp.bottom).offset(10)
+            $0.horizontalEdges.equalToSuperview().inset(28)
+        }
+        
+        infoButton.snp.makeConstraints{
+            $0.top.equalTo(quantityChangeView.snp.bottom).offset(33.5)
+            $0.leading.equalToSuperview().offset(28)
+            $0.bottom.equalToSuperview().inset(40)
+        }
+        
+        goInfoButton.snp.makeConstraints{
+            $0.centerY.equalTo(infoButton.snp.centerY)
+            $0.leading.equalTo(infoButton.snp.trailing).offset(7)
+            $0.height.equalTo(10)
+            $0.width.equalTo(5)
+
+        }
+        
+        quantityChangeView.snp.makeConstraints {
+            $0.height.equalTo(40)
+            $0.width.equalTo(145)
+            $0.top.equalTo(beverageMenuView.snp.bottom).offset(26)
+            $0.centerX.equalToSuperview()
+        }
+        
+        quantityLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.centerX.equalToSuperview()
+        }
+        
+        minusButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(14)
+        }
+        
+        plusButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(-14)
+        }
+        
+        orderButton.snp.makeConstraints{
+            $0.height.equalTo(60)
+            $0.width.equalTo(187.5)
+            $0.leading.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+        
+        cartButton.snp.makeConstraints{
+            $0.height.equalTo(60)
+            $0.width.equalTo(187.5)
+            $0.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+}

--- a/MCDONALDS_iOS/MCDONALDS_iOS/Presentation/Order/OrderViewController.swift
+++ b/MCDONALDS_iOS/MCDONALDS_iOS/Presentation/Order/OrderViewController.swift
@@ -1,0 +1,82 @@
+//
+//  OrderViewController.swift
+//  MCDONALDS_iOS
+//
+//  Created by 이상엽 on 5/18/25.
+//
+
+import UIKit
+
+final class OrderViewController: BaseViewController {
+    
+    //MARK: - Properties
+    
+    private let rootView = OrderView()
+    
+    private lazy var burgerTapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapBurgerView))
+
+    private lazy var comboTapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapComboView))
+    
+    // MARK: - Life Cycle
+    
+    override func loadView() {
+        view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        setNavigationBar(type: .order)
+    }
+    
+    override func setAction() {
+        rootView.burgerCardView.addGestureRecognizer(burgerTapGesture)
+        rootView.comboCardView.addGestureRecognizer(comboTapGesture)
+        rootView.plusButton.addTarget(self, action: #selector(increaseQuantity), for: .touchUpInside)
+        rootView.minusButton.addTarget(self, action: #selector(decreaseQuantity), for: .touchUpInside)
+    }
+    
+    // MARK: - Functions
+    
+    @objc
+    private func didTapBurgerView() {
+        rootView.burgerCardView.layer.borderColor = UIColor.mainYellow.cgColor
+        rootView.burgerCardView.backgroundColor = .mainLightYellow
+
+        rootView.comboCardView.layer.borderColor = UIColor.grayScale200.cgColor
+        rootView.comboCardView.backgroundColor = .white
+    }
+    
+    @objc
+    private func didTapComboView() {
+        rootView.comboCardView.layer.borderColor = UIColor.mainYellow.cgColor
+        rootView.comboCardView.backgroundColor = .mainLightYellow
+
+        rootView.burgerCardView.layer.borderColor = UIColor.grayScale200.cgColor
+        rootView.burgerCardView.backgroundColor = .white
+    }
+    
+    @objc
+    private func increaseQuantity() {
+        rootView.quantity += 1
+        updateLabel()
+    }
+    
+    @objc
+    private func decreaseQuantity() {
+        if rootView.quantity > 0 {
+            rootView.quantity -= 1
+            updateLabel()
+        }
+    }
+    
+    private func updateLabel() {
+        rootView.quantityLabel.text = "\(rootView.quantity)"
+    }
+}


### PR DESCRIPTION
## 🍔 작업 내용
> 주문하기 뷰
- 만들어주신 네비게이션 바와 버튼 함께 사용했습니다
- 단품, 세트 선택 버튼


## 🍟 주요 코드 설명
> 어제 배운 isUserInteractionEnabled 활용하기~
### 단품과 세트를 선택하는 버튼
```Swift
comboCardView.do {
    $0.backgroundColor = .clear
    $0.setBorder(1, borderColor: .grayScale200)
    $0.layer.cornerRadius = 8
    $0.isUserInteractionEnabled = true
}

private lazy var comboTapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapComboView))

rootView.comboCardView.addGestureRecognizer(comboTapGesture)

```
- 승원띠님 PR에서 배운 내용 즉시 적용해보았습니다.
- UIView의 isUserInteractionEnabled를 true로 설정하여 이벤트를 입력받을 수 있도록 했습니다
- UITapGestureRecognizer를 사용하여 탭 됐을 때 실행될 것을 만들었습니다.
- .addGestureRecognizer으로 UIView를 터치했을 때 실행될 액션을 붙였습니다.

## 🍔 구현화면
> 시뮬레이터 사진

|   주문하기 뷰   |
| :----------: |
| <img src = "https://github.com/user-attachments/assets/d049c645-6a7f-45c4-b40e-484148372d09" width ="250"> |

## 🍟 연결된 이슈
> 해결슨
- Connected: #17 


## 🍔 참고자료
https://velog.io/@vvkkiie/iOSSwift-UIView에-touch-event-추가하기

## 🍟 기타 더 이야기해볼 점
뷰 연결 언제하죠